### PR TITLE
Feature/support set type

### DIFF
--- a/src/main/kotlin/com/lapanthere/flink/api/kotlin/serializers/set/SetSerializerSnapshot.kt
+++ b/src/main/kotlin/com/lapanthere/flink/api/kotlin/serializers/set/SetSerializerSnapshot.kt
@@ -1,0 +1,26 @@
+package com.lapanthere.flink.api.kotlin.serializers.set
+
+import org.apache.flink.api.common.typeutils.CompositeTypeSerializerSnapshot
+import org.apache.flink.api.common.typeutils.TypeSerializer
+
+public class SetSerializerSnapshot<T> : CompositeTypeSerializerSnapshot<Set<T>, SetTypeSerializer<T>> {
+
+    public constructor() : super()
+    public constructor(serializerInstance: SetTypeSerializer<T>) : super(serializerInstance)
+
+    override fun getCurrentOuterSnapshotVersion(): Int = CURRENT_VERSION
+
+    override fun createOuterSerializerWithNestedSerializers(nestedSerializers: Array<out TypeSerializer<*>>): SetTypeSerializer<T> {
+        @Suppress("UNCHECKED_CAST")
+        val elementSerializer = nestedSerializers[0] as TypeSerializer<T>
+        return SetTypeSerializer(elementSerializer)
+    }
+
+    override fun getNestedSerializers(outerSerializer: SetTypeSerializer<T>): Array<out TypeSerializer<*>> {
+        return arrayOf(outerSerializer.elementSerializer)
+    }
+
+    public companion object {
+        public const val CURRENT_VERSION: Int = 1
+    }
+}

--- a/src/main/kotlin/com/lapanthere/flink/api/kotlin/serializers/set/SetTypeSerializer.kt
+++ b/src/main/kotlin/com/lapanthere/flink/api/kotlin/serializers/set/SetTypeSerializer.kt
@@ -1,0 +1,89 @@
+package com.lapanthere.flink.api.kotlin.serializers.set
+
+import org.apache.flink.api.common.typeutils.TypeSerializer
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot
+import org.apache.flink.core.memory.DataInputView
+import org.apache.flink.core.memory.DataOutputView
+
+/**
+ * Type Serializer for kotlin set collection
+ * Inspired from [org.apache.flink.api.common.typeutils.base.ListSerializer]
+ */
+public class SetTypeSerializer<T>(
+    public val elementSerializer: TypeSerializer<T>
+) : TypeSerializer<Set<T>>() {
+    override fun isImmutableType(): Boolean = false
+
+    override fun duplicate(): TypeSerializer<Set<T>> {
+        val duplicateElement = elementSerializer.duplicate()
+        return if (duplicateElement === elementSerializer)
+            this
+        else
+            SetTypeSerializer<T>(duplicateElement)
+    }
+
+    override fun createInstance(): Set<T> = emptySet()
+
+    override fun copy(from: Set<T>): Set<T> {
+        if (elementSerializer.isImmutableType) {
+            return HashSet(from)
+        }
+        return HashSet<T>(from.size).apply {
+            for (element in from) {
+                add(elementSerializer.copy(element))
+            }
+        }
+    }
+
+    override fun copy(from: Set<T>, reuse: Set<T>): Set<T> = copy(from)
+
+    override fun getLength(): Int = -1 // var length
+
+    override fun serialize(record: Set<T>, target: DataOutputView) {
+        val size = record.size
+        target.writeInt(size);
+
+        for (element in record) {
+            elementSerializer.serialize(element, target)
+        }
+    }
+
+    override fun deserialize(source: DataInputView): Set<T> {
+        val size = source.readInt()
+        return HashSet<T>(size).apply {
+            repeat(size) {
+                add(elementSerializer.deserialize(source))
+            }
+        }
+    }
+
+    override fun deserialize(reuse: Set<T>, source: DataInputView): Set<T> {
+        return deserialize(source)
+    }
+
+    override fun copy(source: DataInputView, target: DataOutputView) {
+        val size = source.readInt()
+        target.writeInt(size)
+        repeat(size) {
+            elementSerializer.copy(source, target)
+        }
+    }
+
+    override fun snapshotConfiguration(): TypeSerializerSnapshot<Set<T>> {
+        return SetSerializerSnapshot(this)
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SetTypeSerializer<*>
+
+        return elementSerializer == other.elementSerializer
+    }
+
+    override fun hashCode(): Int {
+        return elementSerializer.hashCode()
+    }
+}
+

--- a/src/main/kotlin/com/lapanthere/flink/api/kotlin/typeutils/SetTypeInformation.kt
+++ b/src/main/kotlin/com/lapanthere/flink/api/kotlin/typeutils/SetTypeInformation.kt
@@ -1,0 +1,59 @@
+package com.lapanthere.flink.api.kotlin.typeutils
+
+import com.lapanthere.flink.api.kotlin.serializers.set.SetTypeSerializer
+import org.apache.flink.api.common.ExecutionConfig
+import org.apache.flink.api.common.serialization.SerializerConfig
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeutils.TypeSerializer
+
+/**
+ * Type information for kotlin set collection
+ * Inspired from [org.apache.flink.api.java.typeutils.ListTypeInfo]
+ */
+public class SetTypeInformation<T>(private val elementTypeInfo: TypeInformation<T>) : TypeInformation<Set<T>>() {
+
+    override fun isBasicType(): Boolean = false
+
+    override fun isTupleType(): Boolean = false
+
+    override fun getArity(): Int = 0
+
+    override fun getTotalFields(): Int {
+        // similar as arrays, the lists are "opaque" to the direct field addressing logic
+        // since the list's elements are not addressable, we do not expose them
+        return 1;
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    override fun getTypeClass(): Class<Set<T>> {
+        return Set::class.java as Class<Set<T>>
+    }
+
+    override fun isKeyType(): Boolean = false
+
+    @Deprecated("Deprecated in Java")
+    override fun createSerializer(config: ExecutionConfig?): TypeSerializer<Set<T>> {
+        return createSerializer(config?.serializerConfig)
+    }
+
+    override fun createSerializer(config: SerializerConfig?): TypeSerializer<Set<T>> {
+        val elementSerializer = elementTypeInfo.createSerializer(config)
+        return SetTypeSerializer(elementSerializer)
+    }
+
+    override fun toString(): String {
+        return "SetTypeInformation<$elementTypeInfo>"
+    }
+
+    override fun canEqual(obj: Any?): Boolean = obj?.javaClass == javaClass
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is SetTypeInformation<*>) return false;
+        return other.canEqual(this) && other.elementTypeInfo == this.elementTypeInfo
+    }
+
+    override fun hashCode(): Int {
+        return 31 * elementTypeInfo.hashCode() + 1
+    }
+}

--- a/src/main/kotlin/com/lapanthere/flink/api/kotlin/typeutils/TypeInformation.kt
+++ b/src/main/kotlin/com/lapanthere/flink/api/kotlin/typeutils/TypeInformation.kt
@@ -32,6 +32,10 @@ public fun createTypeInformation(type: KType): TypeInformation<*> {
             val (key, value) = type.arguments.map { it.type ?: Any::class.starProjectedType }
             MapTypeInfo(createTypeInformation(key), createTypeInformation(value))
         }
+        klass.isSubclassOf(Set::class) -> {
+            val (value) = type.arguments.map { it.type ?: Any::class.starProjectedType }
+            SetTypeInformation(createTypeInformation(value))
+        }
         klass.isSubclassOf(Collection::class) -> {
             ListTypeInfo(createTypeInformation(type.arguments.map { it.type ?: Any::class.starProjectedType }.first()))
         }

--- a/src/test/kotlin/com/lapanthere/flink/api/kotlin/serializers/set/SetTypeSerializerTest.kt
+++ b/src/test/kotlin/com/lapanthere/flink/api/kotlin/serializers/set/SetTypeSerializerTest.kt
@@ -1,0 +1,21 @@
+package com.lapanthere.flink.api.kotlin.serializers.set
+
+import com.lapanthere.flink.api.kotlin.typeutils.AbstractDataClassTypeSerializerTest
+import com.lapanthere.flink.api.kotlin.typeutils.SetTypeInformation
+import org.apache.flink.api.common.typeinfo.TypeInformation
+import org.apache.flink.api.common.typeinfo.Types
+import org.junit.jupiter.api.Assertions.*
+
+internal class SetTypeSerializerTest : AbstractDataClassTypeSerializerTest<Set<String>>() {
+    override val typeInformation: TypeInformation<Set<String>> = SetTypeInformation(Types.STRING)
+
+    override fun getTestData(): Array<Set<String>> = arrayOf(
+        emptySet(),
+        hashSetOf<String>("Hello", "World!"),
+        setOf("Hello", "World!"),
+        setOf(),
+        mutableSetOf(),
+        mutableSetOf("Hello", "World!"),
+        linkedSetOf("Hello", "World!"),
+    )
+}

--- a/src/test/kotlin/com/lapanthere/flink/api/kotlin/typeutils/DataClassTypeSerializerTest.kt
+++ b/src/test/kotlin/com/lapanthere/flink/api/kotlin/typeutils/DataClassTypeSerializerTest.kt
@@ -64,3 +64,12 @@ internal class TripleTypeSerializerTest : AbstractDataClassTypeSerializerTest<Tr
             Triple("Super", "Mario", 2),
         )
 }
+
+internal class SetTypeSerializerTest : AbstractDataClassTypeSerializerTest<Set<String>>() {
+    override val typeInformation: TypeInformation<Set<String>> = createTypeInformation()
+
+    override fun getTestData(): Array<Set<String>> =
+        arrayOf(
+            setOf("Hello", "World"),
+        )
+}

--- a/src/test/kotlin/com/lapanthere/flink/api/kotlin/typeutils/SetTypeInformationTest.kt
+++ b/src/test/kotlin/com/lapanthere/flink/api/kotlin/typeutils/SetTypeInformationTest.kt
@@ -1,0 +1,12 @@
+package com.lapanthere.flink.api.kotlin.typeutils
+
+import org.apache.flink.api.common.typeutils.TypeInformationTestBase
+
+class SetTypeInformationTest : TypeInformationTestBase<SetTypeInformation<*>>() {
+    override fun getTestData(): Array<SetTypeInformation<*>> = arrayOf(
+        createTypeInformation<Set<String>>() as SetTypeInformation<*>,
+        createTypeInformation<MutableSet<Pair<String, Int>>>() as SetTypeInformation<*>,
+        createTypeInformation<HashSet<DataClass>>() as SetTypeInformation<*>,
+        createTypeInformation<LinkedHashSet<Int>>() as SetTypeInformation<*>,
+    )
+}


### PR DESCRIPTION
# Support Serializing Kotlin Set Types
Added Set TypeInformation And Serializer

##  New Behavior
kotlin `Set<>` will work out of the box like `List<>` and `Map<>`

## Current Behavior
when trying to serialize type with kotlin `Set<>` there is the following error

```
class java.util.LinkedHashSet cannot be cast to class java.util.List (java.util.LinkedHashSet and java.util.List are in module java.base of loader 'bootstrap')
```

